### PR TITLE
Refactor totals section into reusable view

### DIFF
--- a/ZiferblatEventsCalculator/ContentView.swift
+++ b/ZiferblatEventsCalculator/ContentView.swift
@@ -42,7 +42,7 @@ struct ContentView: View {
                 createButtonSection
 
                 // ⬇️ Новая секция с итогами долгов
-                totalsSection
+                TotalsView(totalOrgDebt: totalOrgDebt, totalCurDebt: totalCurDebt)
 
                 exportSection
                 navigationSection
@@ -89,29 +89,6 @@ struct ContentView: View {
         Section {
             Button("Создать EventInstance") { createInstance() }
                 .disabled(selectedEventID == nil || moneyText.isEmpty || numOfPeopleText.isEmpty)
-        }
-    }
-
-    // NEW: totals
-    private var totalsSection: some View {
-        Section(header: Text("Итого долги")) {
-            HStack {
-                Text("Организаторам")
-                Spacer()
-                Text("\(totalOrgDebt, specifier: "%.2f")")
-                    .monospacedDigit()
-            }
-            HStack {
-                Text("Кураторам")
-                Spacer()
-                Text("\(totalCurDebt, specifier: "%.2f")")
-                    .monospacedDigit()
-            }
-            if totalOrgDebt == 0 && totalCurDebt == 0 {
-                Text("Долгов нет 🎉")
-                    .font(.footnote)
-                    .foregroundColor(.secondary)
-            }
         }
     }
 

--- a/ZiferblatEventsCalculator/TotalsView.swift
+++ b/ZiferblatEventsCalculator/TotalsView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct TotalsView: View {
+    let totalOrgDebt: Double
+    let totalCurDebt: Double
+
+    var body: some View {
+        Section(header: Text("Итого долги")) {
+            DebtRow(label: "Организаторам", amount: totalOrgDebt)
+            DebtRow(label: "Кураторам", amount: totalCurDebt)
+            if totalOrgDebt == 0 && totalCurDebt == 0 {
+                Text("Долгов нет 🎉")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+private struct DebtRow: View {
+    let label: String
+    let amount: Double
+
+    var body: some View {
+        HStack {
+            Text(label)
+            Spacer()
+            Text("\(amount, specifier: "%.2f")")
+                .monospacedDigit()
+        }
+    }
+}
+
+#Preview {
+    List {
+        TotalsView(totalOrgDebt: 12.5, totalCurDebt: 0)
+    }
+}


### PR DESCRIPTION
## Summary
- extract totals UI into a reusable TotalsView with DebtRow
- replace inline totals section in ContentView with TotalsView for cleaner layout

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689d9160f7e0832eae8d12e87caa8825